### PR TITLE
Set a default CELERY_BROKER_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ BROKER_VHOST |  | `'/'` |
 BROKER_USERNAME |  | `'guest'` |
 BROKER_PASSWORD |  | `'guest'` |
 BROKER_PREFIX |  | `'idm.auth.'` |
-**CELERY_BROKER_URL** |  |  |
+CELERY_BROKER_URL |  | `'amqp://guest:guest@localhost:5672//'` |
 IDM_CORE_URL |  | `'http://localhost:8000/'` |
 IDM_CORE_API_URL |  | `'http://localhost:8000/api/'` |
 EMAIL_HOST |  | `None` |

--- a/forsta_auth/settings.py
+++ b/forsta_auth/settings.py
@@ -200,7 +200,7 @@ BROKER_PASSWORD = env('BROKER_PASSWORD', default='guest')
 BROKER_PREFIX = env('BROKER_PREFIX', default='idm.auth.')
 
 
-CELERY_BROKER_URL = env('CELERY_BROKER_URL')
+CELERY_BROKER_URL = env('CELERY_BROKER_URL', default='amqp://guest:guest@localhost:5672//')
 
 OIDC_EXTRA_SCOPE_CLAIMS = 'forsta_auth.oidc.claims.IDMAuthScopeClaims'
 


### PR DESCRIPTION
This makes running the app easier locally during development