### PR TITLE
Social error pages

### DIFF
--- a/forsta_auth/context_processors.py
+++ b/forsta_auth/context_processors.py
@@ -1,3 +1,5 @@
+from email.utils import parseaddr
+
 from django.conf import settings
 from two_factor.utils import default_device
 
@@ -19,8 +21,11 @@ def two_factor_enabled(request):
 
 
 def forsta_auth(request):
+    support_email = parseaddr(settings.SUPPORT_EMAIL)
     return {
         'TEXT_BRANDING': settings.TEXT_BRANDING,
+        'SUPPORT_EMAIL_NAME': support_email[0],
+        'SUPPORT_EMAIL_ADDRESS': support_email[1],
     }
 
 

--- a/forsta_auth/forms.py
+++ b/forsta_auth/forms.py
@@ -1,9 +1,13 @@
 import uuid
 
+import zxcvbn_password.fields
 from django import forms
+from django.conf import settings
 from django.contrib.auth import forms as auth_forms, get_user_model
 from django.utils.translation import ugettext_lazy as _
-import zxcvbn_password.fields
+from two_factor.utils import default_device
+
+from forsta_auth.exceptions import TwoFactorDisabled
 
 
 class AuthenticationForm(auth_forms.AuthenticationForm):
@@ -44,6 +48,11 @@ class AuthenticationForm(auth_forms.AuthenticationForm):
                 username = str(user.pk)
         self.cleaned_data['username'] = username
         return super().clean()
+
+    def confirm_login_allowed(self, user):
+        if not settings.TWO_FACTOR_ENABLED and default_device(user):
+            raise TwoFactorDisabled(None)
+        return super().confirm_login_allowed(user)
 
 
 class SetPasswordForm(auth_forms.SetPasswordForm):

--- a/forsta_auth/middleware.py
+++ b/forsta_auth/middleware.py
@@ -1,0 +1,43 @@
+from http.client import FORBIDDEN, SERVICE_UNAVAILABLE
+
+import inflection
+import social_core.exceptions
+from django.shortcuts import render
+
+from forsta_auth.exceptions import TwoFactorDisabled
+
+
+class SocialAuthExceptionMiddleware:
+    exceptions = {
+        social_core.exceptions.NotAllowedToDisconnect: FORBIDDEN,
+        social_core.exceptions.AuthAlreadyAssociated: FORBIDDEN,
+        social_core.exceptions.AuthCanceled: SERVICE_UNAVAILABLE,
+        TwoFactorDisabled: FORBIDDEN,
+    }  # type: Mapping[Exception, int]
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self._template_names = {}
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def get_template_name_for_exception_class(self, cls):
+        if cls not in self._template_names:
+            name = '/'.join([
+                'exceptions',
+                *[n for n in cls.__module__.split('.') if n != 'exceptions'],
+                inflection.underscore(cls.__name__) + '.html',
+            ])
+            self._template_names[cls] = name
+        return self._template_names[cls]
+
+    def process_exception(self, request, exception):
+        for cls in type(exception).__mro__:
+            if cls in self.exceptions:
+                return render(
+                    request,
+                    self.get_template_name_for_exception_class(cls),
+                    context={'exception': exception},
+                    status=self.exceptions[cls],
+                )

--- a/forsta_auth/middleware.py
+++ b/forsta_auth/middleware.py
@@ -12,7 +12,7 @@ class SocialAuthExceptionMiddleware:
         social_core.exceptions.NotAllowedToDisconnect: FORBIDDEN,
         social_core.exceptions.AuthAlreadyAssociated: FORBIDDEN,
         social_core.exceptions.AuthCanceled: SERVICE_UNAVAILABLE,
-        TwoFactorDisabled: FORBIDDEN,
+        TwoFactorDisabled: SERVICE_UNAVAILABLE,
     }  # type: Mapping[Exception, int]
 
     def __init__(self, get_response):

--- a/forsta_auth/pipeline/two_factor.py
+++ b/forsta_auth/pipeline/two_factor.py
@@ -18,14 +18,14 @@ def add_user_id(user=None, **kwargs):
 
 
 @partial
-def perform_two_factor(user=None, user_id=None, two_factor_complete=False, **kwargs):
+def perform_two_factor(backend, user=None, user_id=None, two_factor_complete=False, **kwargs):
     if not user and user_id:
         User = get_user_model()
         user = User.objects.get(id=uuid.UUID(user_id))
 
     if user and default_device(user) and not two_factor_complete:
         if not settings.TWO_FACTOR_ENABLED:
-            raise TwoFactorDisabled
-        return HttpResponseRedirect(reverse('login'))
+            raise TwoFactorDisabled(backend)
+        return HttpResponseRedirect(reverse('login') + '?from-social')
 
     return {'user': user}

--- a/forsta_auth/settings.py
+++ b/forsta_auth/settings.py
@@ -5,6 +5,7 @@ import kombu
 import os
 from django.urls import reverse
 from django.utils.functional import lazy
+from django.conf import global_settings
 
 from environ import Env
 
@@ -243,12 +244,14 @@ EMAIL_HOST_USER = env('EMAIL_HOST_USER', default=None)
 EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default=None)
 EMAIL_PORT = env('EMAIL_PORT', cast=int, default=587)
 EMAIL_USE_TLS = env('EMAIL_USE_TLS', cast=bool, default=True)
-
 EMAIL_BACKEND = env('EMAIL_BACKEND', default='django.core.mail.backends.console.EmailBackend')
+
+DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default=global_settings.DEFAULT_FROM_EMAIL)
+SERVER_EMAIL = env('SERVER_EMAIL', default=global_settings.SERVER_EMAIL)
+SUPPORT_EMAIL = env('SUPPORT_EMAIL', default=DEFAULT_FROM_EMAIL)
 
 IDM_APPLICATION_ID = '4ff517c5-532f-42ee-afb1-a5d3da2f61d5'
 
-from django.conf import global_settings
 
 PASSWORD_HASHERS = global_settings.PASSWORD_HASHERS
 
@@ -353,4 +356,6 @@ TEXT_BRANDING = {
     'organization_name_in_context': 'the Example Organization',
     'your_account': 'your account',
     'an_account': 'an account',
+    'account': 'account',
+    'accounts': 'accounts',
 }

--- a/forsta_auth/settings.py
+++ b/forsta_auth/settings.py
@@ -86,6 +86,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     # Always include for two-factor auth
     'django_otp.middleware.OTPMiddleware',
+    'forsta_auth.middleware.SocialAuthExceptionMiddleware',
     'forsta_auth.onboarding.middleware.OnboardingMiddleware',
 ]
 

--- a/forsta_auth/templates/exceptions/forsta_auth/two_factor_disabled.html
+++ b/forsta_auth/templates/exceptions/forsta_auth/two_factor_disabled.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block h1_title %}Sorry, you can't log in right now{% endblock %}
+{% block title %}Unable to log in{% endblock %}
+
+{% block content %}
+    <p>Your account has two-factor authentication set up, but {{ TEXT_BRANDING.organization_name_in_context }} have
+        disabled two-factor authentication.</p>
+
+    <p>Please contact <a href="mailto:{{ SUPPORT_EMAIL_ADDRESS }}">{{ SUPPORT_EMAIL_NAME }}</a> for support.</p>
+{% endblock %}

--- a/forsta_auth/templates/exceptions/social_core/auth_already_associated.html
+++ b/forsta_auth/templates/exceptions/social_core/auth_already_associated.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block h1_title %}Sorry, that external account is already associated with another {{ TEXT_BRANDING.account }}{% endblock %}
+{% block title %}Already associated{% endblock %}
+
+{% block content %}
+    <p>You've attempted to link an external account with your {{ TEXT_BRANDING.account }}, but unfortunately the
+        external account is already associated with another {{ TEXT_BRANDING.account }}.</p>
+
+    <p>You can <a href="{% url "logout" %}?next={% url "social:begin" backend=exception.backend.name %}">try again after
+        logging out</a> to see which account it's linked to.</p>
+
+    <p>If you've inadvertently created multiple {{ TEXT_BRANDING.accounts }}s and would like them merged, please email
+        <a href="mailto:{{ SUPPORT_EMAIL_ADDRESS }}">{{ SUPPORT_EMAIL_NAME }}</a>.</p>
+{% endblock %}

--- a/forsta_auth/templates/exceptions/social_core/auth_canceled.html
+++ b/forsta_auth/templates/exceptions/social_core/auth_canceled.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block h1_title %}External authentication cancelled{% endblock %}
+{% block title %}External authentication cancelled{% endblock %}
+
+{% block content %}
+    <p>Unfortunately, external authentication didn't succeed.</p>
+    <p>If this was unexpected, you can <a href="{% url "social:begin" backend=exception.backend.name %}">try again</a>.
+        If you need any assistance, please email
+        <a href="mailto:{{ SUPPORT_EMAIL_ADDRESS }}">{{ SUPPORT_EMAIL_NAME }}</a> for support.</p>
+{% endblock %}

--- a/forsta_auth/templates/exceptions/social_core/not_allowed_to_disconnect.html
+++ b/forsta_auth/templates/exceptions/social_core/not_allowed_to_disconnect.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block h1_title %}Unable to disconnect this external account{% endblock %}
+{% block title %}Can't disconnect external account{% endblock %}
+
+{% block content %}
+    <p>The external account you attempted to disconnect currently provides your only authentication method.</p>
+
+    <p>Before you can remove it, you must either <a href="{% url "password-change" %}">set a password</a> or
+        <a href="{% url "social-logins" %}">associate an alternative external account</a>.</p>
+{% endblock %}

--- a/forsta_auth/tests/test_social.py
+++ b/forsta_auth/tests/test_social.py
@@ -111,7 +111,7 @@ class SocialAuthTestCase(LiveServerTestCase):
         selenium = self.selenium
         selenium.get(urljoin(self.live_server_url, begin_dummy_login_url + '?id=alice'))
         self.assertEqual(selenium.current_url,
-                         urljoin(self.live_server_url, reverse('login')))
+                         urljoin(self.live_server_url, reverse('login') + '?from-social'))
         # Make sure we're being asked for a token
         selenium.find_element_by_name('token-otp_token')
 

--- a/forsta_auth/tests/test_two_factor.py
+++ b/forsta_auth/tests/test_two_factor.py
@@ -1,0 +1,6 @@
+from django.test import TestCase
+
+
+class TwoFactorTestCase(TestCase):
+    def testForbid2FAUsersWhen2FADisabled(self):
+        pass

--- a/forsta_auth/tests/test_two_factor.py
+++ b/forsta_auth/tests/test_two_factor.py
@@ -1,6 +1,40 @@
-from django.test import TestCase
+import http.client
+import uuid
+
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django_otp.plugins.otp_totp.models import TOTPDevice
+from social_django.models import UserSocialAuth
+
+from forsta_auth.models import User
 
 
 class TwoFactorTestCase(TestCase):
-    def testForbid2FAUsersWhen2FADisabled(self):
-        pass
+    def setUp(self):
+        self.password = str(uuid.uuid4())
+        self.user = User(username='user', primary=True)
+        self.user.set_password(self.password)
+        self.user.save()
+
+    @override_settings(TWO_FACTOR_ENABLED=False)
+    def testForbid2FAUsersWhen2FADisabledPassword(self):
+        device = TOTPDevice.objects.create(user=self.user, name='default', confirmed=True)
+
+        response = self.client.post(reverse('login'), {
+            'social_two_factor_login_view-current_step': 'auth',
+            'auth-username': self.user.username,
+            'auth-password': self.password
+        })
+        self.assertEqual(http.client.SERVICE_UNAVAILABLE, response.status_code)
+        self.assertTemplateUsed(response, 'exceptions/forsta_auth/two_factor_disabled.html')
+
+    @override_settings(TWO_FACTOR_ENABLED=False)
+    def testForbid2FAUsersWhen2FADisabledSocial(self):
+        device = TOTPDevice.objects.create(user=self.user, name='default', confirmed=True)
+        UserSocialAuth.objects.create(user=self.user, provider='dummy', uid='alice')
+
+        response = self.client.get(reverse('social:begin',
+                                            kwargs={'backend': 'dummy'}) + '?id=alice',
+                                   follow=True)
+        self.assertEqual(http.client.SERVICE_UNAVAILABLE, response.status_code)
+        self.assertTemplateUsed(response, 'exceptions/forsta_auth/two_factor_disabled.html')

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setuptools.setup(
         "django-dirtyfields",
         "django-templated-email",
         "django-cors-headers",
+        "inflection",
     ],
     extras_require={
         "kerberos": ["pykerberos", "requests-negotiate"],


### PR DESCRIPTION
Catches and handles exceptions raised by python-social-auth, and by two-factor having disabled while there are still 2FA users.

Closes #1 
