### PR TITLE
Add SessionManagementMiddleware

### DIFF
--- a/forsta_auth/settings.py
+++ b/forsta_auth/settings.py
@@ -82,6 +82,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'reversion.middleware.RevisionMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'oidc_provider.middleware.SessionManagementMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
This is required to set the op_browser_state cookie, which is used in implementing single logout functionality for OIDC following [OpenID Connect Session Management 1.0](https://openid.net/specs/openid-connect-session-1_0.html)