### PR TITLE
Allow reset password emails for people without passwords

### DIFF
--- a/forsta_auth/admin.py
+++ b/forsta_auth/admin.py
@@ -15,6 +15,11 @@ class UserSocialAuthInline(admin.TabularInline):
     max_num = 0
 
 
+class UserEmailInline(admin.TabularInline):
+    model = models.UserEmail
+    fields = ('email', 'verified', 'primary')
+
+
 class UserChangeForm(BaseUserChangeForm):
     class Meta(BaseUserChangeForm.Meta):
         field_classes = {}
@@ -28,6 +33,7 @@ class UserAdmin(BaseUserAdmin):
 
     inlines = [
         UserSocialAuthInline,
+        UserEmailInline,
     ]
     form = UserChangeForm
     fieldsets = BaseUserAdmin.fieldsets[:1] + (

--- a/forsta_auth/base_user.py
+++ b/forsta_auth/base_user.py
@@ -6,8 +6,11 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import RegexValidator
 from django.db import models
+from django.utils.functional import cached_property
 
 from django.utils.translation import ugettext_lazy as _
+
+from .backend_meta import BackendMeta
 
 
 if settings.KERBEROS_ENABLED:
@@ -58,6 +61,11 @@ class AbstractBaseUser(KerberosBackedUserMixin, DirtyFieldsMixin, AbstractUser):
 
     def get_username(self):
         return str(self.id)
+
+    @cached_property
+    def social_auth_metas(self):
+        return sorted([BackendMeta.wrap(user_social_auth) for user_social_auth in self.social_auth.all()],
+                      key=lambda s: (s.backend_id, s.username))
 
     class Meta:
         abstract = True

--- a/forsta_auth/forms.py
+++ b/forsta_auth/forms.py
@@ -9,6 +9,8 @@ from two_factor.utils import default_device
 
 from forsta_auth.exceptions import TwoFactorDisabled
 
+UserModel = get_user_model()
+
 
 class AuthenticationForm(auth_forms.AuthenticationForm):
     username = auth_forms.UsernameField(
@@ -27,23 +29,22 @@ class AuthenticationForm(auth_forms.AuthenticationForm):
 
     def clean(self):
         username = self.cleaned_data.get('username')
-        user_model = get_user_model()
         try:
             str(uuid.UUID(username or ''))
         except ValueError:
             try:
-                user = user_model.objects.get(username=username)
-            except user_model.DoesNotExist:
+                user = UserModel.objects.get(username=username)
+            except UserModel.DoesNotExist:
                 try:
-                    user = user_model.objects.get(emails__email=username)
-                except user_model.DoesNotExist:
+                    user = UserModel.objects.get(emails__email=username)
+                except UserModel.DoesNotExist:
                     username = str(uuid.uuid4())
                 else:
                     username = str(user.pk)
             else:
                 try:
-                    user_model.objects.get(emails__email=username)
-                except user_model.DoesNotExist:
+                    UserModel.objects.get(emails__email=username)
+                except UserModel.DoesNotExist:
                     pass
                 username = str(user.pk)
         self.cleaned_data['username'] = username
@@ -71,6 +72,6 @@ class PasswordChangeForm(PasswordSetForm, auth_forms.PasswordChangeForm):
 
 class ProfileForm(forms.ModelForm):
     class Meta:
-        model = get_user_model()
+        model = UserModel
         fields = ('first_name', 'last_name', 'username')
 

--- a/forsta_auth/forms.py
+++ b/forsta_auth/forms.py
@@ -8,6 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 from two_factor.utils import default_device
 
 from forsta_auth.exceptions import TwoFactorDisabled
+from . import models
 
 UserModel = get_user_model()
 
@@ -75,3 +76,12 @@ class ProfileForm(forms.ModelForm):
         model = UserModel
         fields = ('first_name', 'last_name', 'username')
 
+
+class PasswordResetForm(auth_forms.PasswordResetForm):
+    def get_users(self, email):
+        """Given an email, return matching user(s) who should receive a reset.
+
+        This is overridden to also send emails to people that don't have a usable password
+        """
+        return UserModel.objects.filter(emails__in=models.UserEmail.objects.filter(email__iexact=email, verified=True),
+                                        is_active=True).distinct()

--- a/forsta_auth/onboarding/views.py
+++ b/forsta_auth/onboarding/views.py
@@ -291,7 +291,7 @@ class ActivationView(BaseActivationView):
         username, email = self.validate_key(kwargs.get('activation_key'))
         user = self.get_user(username)
         try:
-            UserEmail.objects.create(user=user, email=email)
+            UserEmail.objects.create(user=user, email=email, primary=True, verified=True)
         except IntegrityError as e:
             raise ActivationError(
                 self.EMAIL_IN_USE_MESSAGE,

--- a/forsta_auth/templates/forsta_auth/user_detail.html
+++ b/forsta_auth/templates/forsta_auth/user_detail.html
@@ -30,7 +30,7 @@
                         <th>Disassociate</th>
                     </tr>
                     </thead>
-                    <tbody>{% for user_social_auth in associated %}
+                    <tbody>{% for user_social_auth in user.social_auth_metas %}
                         <tr class="social-account-{{ user_social_auth.backend_id }}">
                             <td class="align-center">
                                 <i class="{{ user_social_auth.font_icon }} fa-2x social-account-icon-{{ user_social_auth.backend_id }}" title="{{ user_social_auth.name }}"> </i>

--- a/forsta_auth/templates/idm-auth/social-logins.html
+++ b/forsta_auth/templates/idm-auth/social-logins.html
@@ -18,7 +18,7 @@
                 <th>Disassociate</th>
             </tr>
             </thead>
-            <tbody>{% for user_social_auth in associated %}
+            <tbody>{% for user_social_auth in user.social_auth_metas %}
                 <tr class="social-account-{{ user_social_auth.backend_id }}">
                     <td class="align-center">
                         <i class="{{ user_social_auth.font_icon }} fa-2x social-account-icon-{{ user_social_auth.backend_id }}" title="{{ user_social_auth.name }}"> </i>

--- a/forsta_auth/templates/registration/password_reset_email.html
+++ b/forsta_auth/templates/registration/password_reset_email.html
@@ -1,0 +1,18 @@
+{% load i18n %}{% autoescape off %}
+{% blocktrans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endblocktrans %}
+{%  if user.has_usable_password %}
+{% trans "Please go to the following page and choose a new password:" %}
+{% block reset_link %}
+{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+{% endblock %}{% else %}
+Your account is not set up with a password; you can only log in via external services.
+{% endif %}{% if user.social_auth_metas %}{% regroup user.social_auth_metas by backend_id as social_auth_metas %}
+You can{% if user.has_usable_password %} also{% endif %} log in using {{ social_auth_metas|pluralize:"this,these" }} external service{{ social_auth_metas|pluralize }}:
+{% for group in social_auth_metas %}
+* {{ group.list.0.name }} - {{ protocol }}://{{ domain }}{% url 'social:begin' backend=group.grouper %}{% endfor %}{% endif %}
+
+{% trans "Thanks for using our site!" %}
+
+{% blocktrans %}The {{ site_name }} team{% endblocktrans %}
+
+{% endautoescape %}

--- a/forsta_auth/tests/test_registration.py
+++ b/forsta_auth/tests/test_registration.py
@@ -34,7 +34,7 @@ class RegistrationTestCase(LiveServerTestCase):
 
     @creates_idm_core_user
     def testNewRegistration(self, identity_id):
-        from forsta_auth.models import User
+        from forsta_auth.models import User, UserEmail
 
         # This is the whole signup flow
         selenium = self.selenium
@@ -85,6 +85,13 @@ class RegistrationTestCase(LiveServerTestCase):
 
         user = User.objects.get()
         self.assertTrue(user.is_active)
+        self.assertEqual(user.email, 'edgar@example.org')
+
+        user_email = user.emails.get()  # type: UserEmail
+        self.assertTrue(user_email.primary)
+        self.assertTrue(user_email.verified)
+        self.assertEqual(user_email.email, 'edgar@example.org')
+
         if settings.BROKER_ENABLED:
             self.assertEqual(user.identity_id, identity_id)
 

--- a/forsta_auth/urls.py
+++ b/forsta_auth/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     url(r'^password/$', views.PasswordChangeView.as_view(), name='password_change'),
     url(r'^password/done/$', views.PasswordChangeDoneView.as_view(), name='password_change_done'),
 
-    path('password-reset/', auth_views.PasswordResetView.as_view(), name='password_reset'),
+    path('password-reset/', views.PasswordResetView.as_view(), name='password_reset'),
     path('password-reset/done/', auth_views.PasswordResetDoneView.as_view(), name='password_reset_done'),
     path('reset/<uidb64>/<token>/', views.PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('reset/done/', auth_views.PasswordResetCompleteView.as_view(), name='password_reset_complete'),

--- a/forsta_auth/views/self_service.py
+++ b/forsta_auth/views/self_service.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.views import PasswordResetConfirmView as BasePasswordResetConfirmView
+from django.contrib.auth.views import PasswordResetView as BasePasswordResetView
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.module_loading import import_string
@@ -8,11 +9,10 @@ from django.views import View
 from django.views.generic import TemplateView, UpdateView, DetailView
 from two_factor.utils import default_device
 
-from forsta_auth import backend_meta
+from forsta_auth import backend_meta, context_processors, forms
 from forsta_auth.backend_meta import BackendMeta
-from .. import forms
 
-__all__ = ['ProfileView', 'ProfileFormView', 'SocialLoginsView', 'IndexView']
+__all__ = ['ProfileView', 'ProfileFormView', 'SocialLoginsView', 'IndexView', 'PasswordResetView']
 
 AUTH_USER_FORM = import_string(getattr(settings, 'AUTH_USER_FORM',
                                        'forsta_auth.forms.ProfileForm'))
@@ -58,3 +58,7 @@ class SocialLoginsView(LoginRequiredMixin, TemplateView):
                            for user_social_auth in self.request.user.social_auth.all()],
             'social_backends': list(sorted([bm for bm in backend_meta.BackendMeta.registry.values() if bm.show], key=lambda sb: sb.name)),
         }
+
+
+class PasswordResetView(BasePasswordResetView):
+    form_class = forms.PasswordResetForm


### PR DESCRIPTION
Users with social auth can now get recovery emails telling then which services they have associated with their account.